### PR TITLE
Made the timeline a bit more pretty on mobile devices

### DIFF
--- a/boxxy/public/css/layout.css
+++ b/boxxy/public/css/layout.css
@@ -577,7 +577,7 @@ nav select {
     }
 
     h1 {
-        font-size: 60px;
+        font-size: 55px;
         margin-bottom: 20px;
     }
 

--- a/boxxy/public/css/timeline.css
+++ b/boxxy/public/css/timeline.css
@@ -229,6 +229,8 @@ Modules - reusable parts of our design
   color: #303e49;
   margin-bottom: 0;
   margin-top: 0;
+  font-size: 20px;
+  font-size: 1.25rem;
 }
 .cd-timeline-content p, .cd-timeline-content .cd-read-more, .cd-timeline-content .cd-date {
   font-size: 13px;


### PR DESCRIPTION
The h2's in the timeline were too big on mobile devices, this fixes that.
